### PR TITLE
conda-forge.yml: remove abi_migration for 1.26.x

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma10
 expat:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-aarch64:alma10
 expat:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,7 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '14'
+- '15'
 c_stdlib:
 - sysroot
 c_stdlib_version:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '14'
+- '15'
 docker_image:
 - quay.io/condaforge/linux-anvil-ppc64le:alma10
 expat:

--- a/.ci_support/migrations/ffmpeg9.yaml
+++ b/.ci_support/migrations/ffmpeg9.yaml
@@ -1,8 +1,0 @@
-__migrator:
-  build_number: 1
-  commit_message: Rebuild for ffmpeg 9
-  kind: version
-  migration_number: 1
-ffmpeg:
-- '9'
-migrator_ts: 1786327004.7804887

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '19'
+- '21'
 expat:
 - '2'
 ffmpeg:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '19'
+- '21'
 c_stdlib:
 - macosx_deployment_target
 c_stdlib_version:
@@ -17,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '19'
+- '21'
 expat:
 - '2'
 ffmpeg:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -13,6 +13,5 @@ github:
   tooling_branch_name: main
 provider:
   linux_aarch64: default
-  linux_ppc64le: default
   osx_arm64: default
 test: native_and_emulated

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,6 +1,4 @@
 bot:
-  abi_migration_branches:
-  - 1.26.x
   version_updates:
     even_odd_versions: true
 build_platform:

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -3,7 +3,6 @@ bot:
     even_odd_versions: true
 build_platform:
   linux_aarch64: linux_aarch64
-  linux_ppc64le: linux_ppc64le
   osx_64: osx_64
 conda_build:
   pkg_format: '2'

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 71e6eafb4fff2a66d1bb0ba8d078224dfe7e3397307d8c0bba3dc23606e08f51
 
 build:
-  number: 1
+  number: 2
 
 requirements:
   build:


### PR DESCRIPTION
[ci skip] ***NO_CI***
@conda-forge-admin, please rerender
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
